### PR TITLE
docs: Consistent contributing.md for all roles - allow role specific contributing.md section

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -19,4 +19,4 @@ exclude_paths:
   - .github/
   - examples/roles/
 mock_roles:
-  - linux-system-roles.template
+  - linux-system-roles.systemd

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -35,7 +35,7 @@ jobs:
               sed "/galaxy_info:/a\  namespace: linux_system_roles" -i "$mm"
             fi
             if ! grep -q '^  *role_name:' "$mm"; then
-              sed "/galaxy_info:/a\  role_name: template" -i "$mm"
+              sed "/galaxy_info:/a\  role_name: systemd" -i "$mm"
             fi
           fi
 

--- a/.github/workflows/weekly_ci.yml
+++ b/.github/workflows/weekly_ci.yml
@@ -4,7 +4,7 @@ name: Weekly CI trigger
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
   schedule:
-    - cron: 0 0 * * 6
+    - cron: 0 23 * * 6
 env:
   BRANCH_NAME: weekly-ci
   COMMIT_MESSAGE: This PR is to trigger periodic CI testing

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,24 @@
+Contributing to the systemd Linux System Role
+=============================================
+
+Where to start
+--------------
+
+The first place to go is [Contribute](https://linux-system-roles.github.io/contribute.html).
+This has all of the common information that all role developers need:
+
+* Role structure and layout
+* Development tools - How to run tests and checks
+* Ansible recommended practices
+* Basic git and github information
+* How to create git commits and submit pull requests
+
+**Bugs and needed implementations** are listed on
+[Github Issues](https://github.com/linux-system-roles/systemd/issues).
+Issues labeled with
+[**help wanted**](https://github.com/linux-system-roles/systemd/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+are likely to be suitable for new contributors!
+
+**Code** is managed on [Github](https://github.com/linux-system-roles/systemd), using
+[Pull Requests](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests).
+


### PR DESCRIPTION
Provide a single, consistent contributing.md for all roles.  This mostly links to
and summarizes https://linux-system-roles.github.io/contribute.html

Allow for a role specific section which typically has information about
role particulars, role debugging tips, etc.

See https://github.com/linux-system-roles/.github/pull/19

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
