### PR TITLE
feat: add support for transactional update

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ List of unit files that shall be masked via systemd.
 
 List of unit files that shall be unmasked via systemd.
 
-
 ### systemd_transactional_update_reboot_ok
 
 This variable is used to handle reboots required by transactional updates. If a transactional update requires a reboot, the role will proceed with the reboot if systemd_transactional_update_reboot_ok is set to true. If set to false, the role will notify the user that a reboot is required, allowing for custom handling of the reboot requirement. If this variable is not set, the role will fail to ensure the reboot requirement is not overlooked.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ List of unit files that shall be masked via systemd.
 
 List of unit files that shall be unmasked via systemd.
 
+
+### systemd_transactional_update_reboot_ok
+
+This variable is used to handle reboots required by transactional updates. If a transactional update requires a reboot, the role will proceed with the reboot if systemd_transactional_update_reboot_ok is set to true. If set to false, the role will notify the user that a reboot is required, allowing for custom handling of the reboot requirement. If this variable is not set, the role will fail to ensure the reboot requirement is not overlooked.
+
 Example of setting the variables:
 
 ```yaml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,3 +11,4 @@ systemd_enabled_units: []
 systemd_disabled_units: []
 systemd_masked_units: []
 systemd_unmasked_units: []
+systemd_transactional_update_reboot_ok: null

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,12 +12,47 @@
       set_fact:
         __systemd_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
 
+- name: Determine if system is transactional update and set flag
+  when: not __systemd_is_transactional is defined
+  block:
+    - name: Check if transactional-update exists in /sbin
+      stat:
+        path: /sbin/transactional-update
+      register: __transactional_update_stat
+
+    - name: Set flag if transactional-update exists
+      set_fact:
+        __systemd_is_transactional: "{{ __transactional_update_stat.stat.exists }}"
+
 - name: Ensure required packages are installed
   package:
     name: "{{ __systemd_packages }}"
     state: present
     use: "{{ (__systemd_is_ostree | d(false)) |
               ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
+  register: systemd_package_result
+
+- name: Handle reboot for transactional update systems
+  when:
+    - __systemd_is_transactional | d(false)
+    - systemd_package_result is changed
+  block:
+    - name: Notify user that reboot is needed to apply changes
+      debug:
+        msg: >
+          Reboot required to apply changes due to transactional updates.
+
+    - name: Reboot transactional update systems
+      reboot:
+        msg: Rebooting the system to apply transactional update changes.
+      when: systemd_transactional_update_reboot_ok | bool
+
+    - name: Fail if reboot is needed and not set
+      fail:
+        msg: >
+          Reboot is required but not allowed. Please set 'systemd_transactional_update_reboot_ok' to proceed.
+      when:
+        - systemd_transactional_update_reboot_ok is none
 
 - name: Deploy unit files
   copy:


### PR DESCRIPTION
Enhancement: - Added a block to handle reboots for transactional update systems on systemd package changes. Update README.

Reason: Ensure necessary reboots are managed, as changes on transactional update systems are applied in a separate snapshot and require a reboot to take effect.

Result: Manages system reboots for transactional update systems when a package is installed.

Issue Tracker Tickets (Jira or BZ if any):na
