### PR TITLE
fix: ansible 2.19+ removed invocation as part of the data rework. also fixed some tests

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -133,8 +133,8 @@
       __systemd_unit_file_templates_result.get('results', []) +
       __systemd_unit_files_absent_result.get('results', []) }}"
     __users_with_changes: "{{ all_results | selectattr('changed', 'defined') |
-      selectattr('changed') | map(attribute='invocation') |
-      map(attribute='module_args') | map(attribute='owner') | unique | list }}"
+      selectattr('changed') | map(attribute='item') | map(attribute='user') |
+      unique | list }}"
 
 - name: Manage units
   include_tasks: manage_units.yml

--- a/tasks/manage_unit_files.yml
+++ b/tasks/manage_unit_files.yml
@@ -76,7 +76,6 @@
           file:
             path: "{{ __path }}/{{ __file }}"
             state: absent
-            owner: "{{ item.user }}"  # only needed for daemon_reload which happens later
           loop: "{{ __systemd_absent }}"
           register: __systemd_unit_files_absent_result
 
@@ -89,9 +88,15 @@
 
         - name: Remove dropin directory if no more files
           file:
-            path: "{{ item['invocation']['module_args']['path'] }}"
+            path: "{{ __dropin_dir }}"
             state: absent
           loop: "{{ __systemd_find.results | d([]) }}"
+          vars:
+            __find_item: "{{ item.item }}"
+            __dropin_unit: "{{ __find_item.item | basename |
+              regex_replace('[.]j2$', '') }}"
+            __dropin_dir: "{{ __find_item.units_dir ~ '/' ~
+              '.'.join(__dropin_unit.split('.')[:-1]) ~ '.d' }}"
           when:
             - __systemd_list_name == "systemd_dropins"
             - item.matched == 0

--- a/tests/tests_basic.yml
+++ b/tests/tests_basic.yml
@@ -298,3 +298,37 @@
           - test_unit_state.stdout is search("UnitFileState=enabled") or
             test_unit_state.stdout is search("UnitFileState=static")
           - test_unit_state.stdout is search("SubState=running")
+
+- name: Ensure that removing unit file dropins works correctly
+  hosts: all
+  vars:
+    systemd_dropins:
+      - item: nested/dir/templates/foo.service.conf.j2
+        state: absent
+  tasks:
+    - name: Test dropin removal
+      block:
+        - name: Run the role
+          ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
+        - name: Stat the dropin directory path after removal
+          stat:
+            path: /etc/systemd/system/foo.service.d
+          register: dropin_removed
+
+        - name: Check that dropin directory was removed
+          assert:
+            that:
+              - not dropin_removed.stat.exists
+      always:
+        - name: Clean up dropin directory
+          file:
+            path: /etc/systemd/system/foo.service.d
+            state: absent
+          register: __dropin_cleanup
+          tags: tests::cleanup
+
+        - name: Reload systemd if cleanup removed anything
+          systemd:
+            daemon_reload: true
+          when: __dropin_cleanup is changed
+          tags: tests::cleanup

--- a/tests/tests_basic.yml
+++ b/tests/tests_basic.yml
@@ -330,5 +330,5 @@
         - name: Reload systemd if cleanup removed anything
           systemd:
             daemon_reload: true
-          when: __dropin_cleanup is changed
+          when: __dropin_cleanup is changed  # noqa no-handler
           tags: tests::cleanup

--- a/tests/tests_user_units.yml
+++ b/tests/tests_user_units.yml
@@ -197,7 +197,7 @@
 
         - name: Verify files are absent
           stat:
-            path: "{{ __units_dir }}/{{ item.item }}"
+            path: "{{ __units_dir }}/{{ item.item | basename }}"
           register: __stat
           failed_when: __stat.stat.exists
           loop: "{{ __systemd_unit_files }}"
@@ -212,9 +212,9 @@
           loop: "{{ __systemd_unit_file_templates }}"
           vars:
             __units_dir: "{{ __systemd_user_info[item.user]['units_dir'] }}"
-            __dest: "{{ item.item | regex_replace('[.]j2$', '') }}"
+            __dest: "{{ item.item | basename | regex_replace('[.]j2$', '') }}"
 
-        - name: Verify dropin files are absent
+        - name: Verify dropin directories are absent
           stat:
             path: "{{ __path }}"
           register: __stat
@@ -222,10 +222,9 @@
           loop: "{{ __systemd_dropins }}"
           vars:
             __units_dir: "{{ __systemd_user_info[item.user]['units_dir'] }}"
-            __dest: "{{ item.item | regex_replace('[.]j2$', '') }}"
+            __dest: "{{ item.item | basename | regex_replace('[.]j2$', '') }}"
             __path: "{{ __units_dir }}/\
-              {{ '.'.join(__dest.split('.')[:-1]) }}.d/\
-              99-override.conf"
+              {{ '.'.join(__dest.split('.')[:-1]) }}.d"
 
         - name: Verify no lingering
           stat:


### PR DESCRIPTION
Cause:

Hello, ansible 2.19+ removed invocation as part of the data tagging rework.

Consequences:

The end result is that any changes end up half applied:

```
TASK [fedora.linux_system_roles.systemd : Reload systemd] **********************
[WARNING]: Falling back to Ansible unique filter as Jinja2 one failed: object of
type 'dict' has no attribute 'invocation'
[ERROR]: Task failed: object of type 'dict' has no attribute 'invocation'
```

At `tasks/main.yml`, task `Reload systemd`, in the `__users_with_changes` expression. The file drop-ins are written to disk, but the daemon-reload and everything after it fails.

You can check with something like the following example

```yaml
- hosts: localhost
  gather_facts: false
  tasks:
    - name: write in loop
      ansible.builtin.copy:
        content: "test\n"
        dest: /tmp/{{ item }}
      loop: [a]
      register: r
    - name: tasks/main.yml:127
      ansible.builtin.debug:
        msg: "{{ r.results | selectattr('changed', 'defined') |
          selectattr('changed') | map(attribute='invocation') |
          map(attribute='module_args') | map(attribute='owner') |
          unique | list }}"
```

Fix:

derive the values from the loop's `item` var instead of `invocation`.

Also, while trying to make sure the tests would catch this in the future I found three things:

1. tests/tests_user_units.yml — missing `basename` on "Verify files are absent" and "Verify template files are absent" tasks
2. tests/tests_user_units.yml — repointed the dropin absence check at the directory instead of the file inside it. This means if the role ever half breaks again it can be caught.
3. tests/tests_basic.yml — added a new play to remove the dropin earlier and assert it no longer exists. This is another check for systems beyond EL8.

result:

dropins work again.

Thank you for your work on this role!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of affected users when reloading systemd units.
  * Corrected cleanup of absent unit files and drop-in directories.
  * Ensured drop-in directories are fully removed when configured with `state: absent`.
  * Improved destination handling for unit and template files.

* **Tests**
  * Added coverage confirming drop-in directory cleanup.
  * Updated verification for complete directory removal and correct file destinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->